### PR TITLE
Fixes infinite looping (#7)

### DIFF
--- a/lib/mktemp.js
+++ b/lib/mktemp.js
@@ -1,40 +1,14 @@
 var fs = require('fs'),
     randomstring = require('./randomstring');
 
-
-/**
- * create unique name file.
- *
- * @param {String} template template string for filename.
- * @param {Function} callback callback function.
- * @throws {TypeError} cannot use Promise and callback function is not found.
- * @return {Promise} Promise.
- */
-function createFile(template, callback) {
+function tryCreateFile(template, retryAttempts, callback) {
   var filename = randomstring.generate(template);
-
-  // callback is not a Function
-  if (typeof callback !== 'function') {
-    // can use Promise
-    if (typeof Promise === 'function') {
-      // return Promise
-      return new Promise(function(resolve, reject) {
-        createFile(template, function(err, filename) {
-          (err) ? reject(err) : resolve(filename);
-        });
-      });
-    } else {
-      // throw TypeError when cannot use Promise
-      throw new TypeError('callback function required');
-    }
-  }
 
   fs.open(filename, 'ax+', 384 /*=0600*/, function(err, fd) {
     if (err) {
-      if (err.code === 'EEXIST') {
-        // FIXME: infinite loop
+      if (err.code === 'EEXIST' && retryAttempts > 0) {
         setImmediate(function(tmpl, cb) {
-          createFile(tmpl, cb);
+          tryCreateFile(tmpl, retryAttempts - 1, cb);
         }, template, callback);
 
         return;
@@ -54,6 +28,38 @@ function createFile(template, callback) {
   });
 }
 
+/**
+ * create unique name file.
+ *
+ * @param {String} template template string for filename.
+ * @param {Function} callback callback function.
+ * @throws {TypeError} cannot use Promise and callback function is not found.
+ * @return {Promise} Promise.
+ */
+function createFile(template, callback) {
+
+  var retryAttempts;
+
+  // callback is not a Function
+  if (typeof callback !== 'function') {
+    // can use Promise
+    if (typeof Promise === 'function') {
+      // return Promise
+      return new Promise(function(resolve, reject) {
+        createFile(template, function(err, filename) {
+          (err) ? reject(err) : resolve(filename);
+        });
+      });
+    } else {
+      // throw TypeError when cannot use Promise
+      throw new TypeError('callback function required');
+    }
+  }
+
+  retryAttempts = randomstring.outcomeCount(template);
+  tryCreateFile(template, retryAttempts, callback);
+}
+
 
 /**
  * sync version createFile.
@@ -64,15 +70,16 @@ function createFile(template, callback) {
  */
 function createFileSync(template) {
   var isExist, filename, fd;
+  var retryAttempts = randomstring.outcomeCount(template);
 
-  // FIXME: infinite loop
   do {
+    retryAttempts = retryAttempts - 1;
     isExist = false;
     filename = randomstring.generate(template);
     try {
       fd = fs.openSync(filename, 'ax+', 384 /*=0600*/);
     } catch (e) {
-      if (e.code === 'EEXIST') {
+      if (e.code === 'EEXIST' && retryAttempts > 0) {
         isExist = true;
       } else {
         throw e;
@@ -85,6 +92,26 @@ function createFileSync(template) {
   return filename;
 }
 
+function tryCreateDir(template, retryAttempts, callback) {
+  var dirname = randomstring.generate(template);
+
+  fs.mkdir(dirname, 448 /*=0700*/, function(err) {
+    if (err) {
+      if (err.code === 'EEXIST' && retryAttempts > 0) {
+        setImmediate(function(tmpl, cb) {
+          tryCreateDir(tmpl, retryAttempts - 1, cb);
+        }, template, callback);
+
+        return;
+      }
+
+      // dirname set to null if throws error
+      dirname = null;
+    }
+
+    callback(err, dirname);
+  });
+}
 
 /**
  * create unique name dir.
@@ -95,7 +122,7 @@ function createFileSync(template) {
  * @return {Promise} Promise.
  */
 function createDir(template, callback) {
-  var dirname = randomstring.generate(template);
+  var retryAttempts;
 
   // callback is not a Function
   if (typeof callback !== 'function') {
@@ -113,23 +140,8 @@ function createDir(template, callback) {
     }
   }
 
-  fs.mkdir(dirname, 448 /*=0700*/, function(err) {
-    if (err) {
-      if (err.code === 'EEXIST') {
-        // FIXME: infinite loop
-        setImmediate(function(tmpl, cb) {
-          createDir(tmpl, cb);
-        }, template, callback);
-
-        return;
-      }
-
-      // dirname set to null if throws error
-      dirname = null;
-    }
-
-    callback(err, dirname);
-  });
+  retryAttempts = randomstring.outcomeCount(template);
+  tryCreateDir(template, retryAttempts, callback);
 }
 
 
@@ -141,15 +153,16 @@ function createDir(template, callback) {
  */
 function createDirSync(template) {
   var isExist, dirname;
+  var retryAttempts = randomstring.outcomeCount(template);
 
-  // FIXME: infinite loop
   do {
+    retryAttempts = retryAttempts - 1;
     isExist = false;
     dirname = randomstring.generate(template);
     try {
       fs.mkdirSync(dirname, 448 /*=0700*/);
     } catch (e) {
-      if (e.code === 'EEXIST') {
+      if (e.code === 'EEXIST' && retryAttempts > 0) {
         isExist = true;
       } else {
         throw e;

--- a/lib/randomstring.js
+++ b/lib/randomstring.js
@@ -4,6 +4,33 @@
 var TABLE = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
     TABLE_LEN = TABLE.length;
 
+function matchPlaceholder(template) {
+  return template.match(/(X+)[^X]*$/);
+}
+
+/**
+ * count the number of possible outcomes for the template
+ *
+ * @param {String} template template string.
+ * @throws {TypeError} if template is not a String.
+ * @return {Number} count of possible outcomes.
+ */
+function outcomeCount(template) {
+  var matches;
+
+  if (typeof template !== 'string') {
+    throw new TypeError('template must be a String: ' + template);
+  }
+
+  matches = matchPlaceholder(template);
+
+  if (matches === null) {
+    return 1;
+  }
+  else {
+    return Math.pow(TABLE_LEN, matches[1].length);
+  }
+}
 
 /**
  * generate random string from template.
@@ -22,7 +49,7 @@ function generate(template) {
     throw new TypeError('template must be a String: ' + template);
   }
 
-  match = template.match(/(X+)[^X]*$/);
+  match = matchPlaceholder(template);
 
   // return template if not has placeholder
   if (match === null) {
@@ -44,5 +71,6 @@ function generate(template) {
  * export.
  */
 module.exports = {
-  generate: generate
+  generate: generate,
+  outcomeCount: outcomeCount
 };

--- a/test/mktemp.js
+++ b/test/mktemp.js
@@ -111,6 +111,24 @@ describe('mktemp', function() {
 
     });
 
+    describe('when no files are available', function() {
+
+      beforeEach(function () {
+        sinon.stub(fs, 'open').callsArgWith(3, { code: 'EEXIST' });
+      });
+
+      afterEach(function () {
+        fs.open.restore();
+      });
+
+      it('throws an error', function (done) {
+        mktemp.createFile('temp-X', function (err) {
+          assert.equal('EEXIST', err.code);
+          done();
+        });
+      });
+    });
+
     describe('when unsupported Promise', function() {
 
       if (isPromise) {
@@ -169,6 +187,28 @@ describe('mktemp', function() {
         });
       });
 
+    });
+
+    describe('when no files are available', function() {
+
+      before(function() {
+        sinon.stub(fs, 'openSync').throws({ code: 'EEXIST' });
+      });
+
+      after(function() {
+        fs.openSync.restore();
+      });
+
+      it('throws an error', function() {
+        assert.throws(function() {
+          try {
+            mktemp.createFileSync('foo-X');
+          } catch (e) {
+            assert.equal('EEXIST', e.code);
+            throw e;
+          }
+        });
+      });
     });
 
     describe('when duplicate path', function() {
@@ -303,6 +343,24 @@ describe('mktemp', function() {
 
     });
 
+    describe('when no files are available', function() {
+
+      beforeEach(function () {
+        sinon.stub(fs, 'mkdir').callsArgWith(2, { code: 'EEXIST' });
+      });
+
+      afterEach(function () {
+        fs.mkdir.restore();
+      });
+
+      it('throws an error', function (done) {
+        mktemp.createDir('temp-X', function (err) {
+          assert.equal('EEXIST', err.code);
+          done();
+        });
+      });
+    });
+
     describe('when unsupported Promise', function() {
 
       if (isPromise) {
@@ -388,6 +446,26 @@ describe('mktemp', function() {
 
     });
 
-  });
+    describe('when no files are available', function() {
 
+      before(function() {
+        sinon.stub(fs, 'mkdirSync').throws({ code: 'EEXIST' });
+      });
+
+      after(function() {
+        fs.mkdirSync.restore();
+      });
+
+      it('throws an error', function() {
+        assert.throws(function() {
+          try {
+            mktemp.createDirSync('foo');
+          } catch (e) {
+            assert.equal('EEXIST', e.code);
+            throw e;
+          }
+        });
+      });
+    });
+  });
 });

--- a/test/randomstring.js
+++ b/test/randomstring.js
@@ -3,6 +3,28 @@ var assert = require('power-assert'),
 
 describe('randomstring', function() {
 
+  describe('.outcomeCount()', function () {
+    describe('when missing template placeholders', function () {
+      it('returns 1', function () {
+        assert.equal(1, randomstring.outcomeCount('no-placeholder'));
+      });
+    });
+
+    describe('when template has a single placeholder', function () {
+      // 62 == TABLE_LEN
+      it('returns 62', function () {
+        assert.equal(62, randomstring.outcomeCount('short-placeholder-X'));
+      });
+    });
+
+    describe('when template has 7 placeholders', function () {
+      // 3521614606208 == TABLE_LEN ^ 7
+      it('returns 3521614606208', function () {
+        assert.equal(3521614606208, randomstring.outcomeCount('short-placeholder-XXXXXXX'));
+      });
+    });
+  });
+
   describe('.generate()', function() {
 
     it('should generated random string', function() {


### PR DESCRIPTION
Limits attempts at temp-file creation to avoid infinite loops, returning the most recent `'EEXIST'` exception if a suitable filename cannot be found.

Note that the number of retries attempted is equal to the total number of filenames possible for a given template. This means that failure may (and for n > 1 filenames likely _will_) occur before all possible filenames are exhausted. This trade-off is intended to provide a "reasonable" number of retry attempts without requiring a full scan/log of previous attempts.

Thanks for your consideration!