### PR TITLE
change version to 2.0.4

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# 2.0.4 / 2026-08-24
+
+- update engines
+- maintenance update
+
 # 2.0.3 / 2026-04-23
 
 - maintenance update

--- a/README.md
+++ b/README.md
@@ -120,11 +120,6 @@ create directory of unique dirname. return Promise if callback is not passed.
 
 sync version createDir.
 
-## Contributors
-
-- [Michael Ficarra](https://github.com/michaelficarra)
-- [rjz](https://github.com/rjz)
-
 ## License
 
 The MIT license.

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "description": "create temporary files and directories",
   "version": "2.0.3",
   "author": "sasa+1 <sasaplus1@gmail.com>",
-  "contributors": [
-    "Michael Ficarra <github.public.email@michael.ficarra.me>",
-    "rjz <rj@rjzaworski.com>"
-  ],
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",
     "@biomejs/biome": "2.5.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mktemp",
   "description": "create temporary files and directories",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "sasa+1 <sasaplus1@gmail.com>",
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",


### PR DESCRIPTION
## Overview

Release prep for 2.0.4. The only user-facing change since 2.0.3 is #430, which
widened `engines.node` to accept Node 26; the rest is dependency maintenance.

The contributors list now points at
https://github.com/sasaplus1/mktemp/graphs/contributors, which stays up to date
on its own.

## How to read the diff

Three commits, readable one by one. 10 changed lines, no generated files.

1. `remove contributors list` — README.md and package.json
2. `update HISTORY.md`
3. `change version to 2.0.4`
